### PR TITLE
Fix für Fehler in Aufg 7

### DIFF
--- a/Übung/dhbw_am_uebunsblatt01.tex
+++ b/Übung/dhbw_am_uebunsblatt01.tex
@@ -109,7 +109,7 @@ und
 & g :  \mathbb{R}^3  \to \mathbb{R} \\
 & g(x,y,z) = x^2 + y^2 + z^2 \;. 
 \end{align*}
-Berechnen Sie den Gradienten von $f \circ g$.
+Berechnen Sie den Gradienten von $g \circ f$.
 
 
 


### PR DESCRIPTION
g gibt ein Skalar aus und f erwartet einen Vektor der Dimension 3x1. Somit wäre in diesem Fall eine Verkettung nicht möglich. Für den Fall g verkettet f wäre es aber möglich.